### PR TITLE
feat: integrate Prometheus and Grafana for monitoring

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -52,6 +52,34 @@ services:
     depends_on:
       - postgres
 
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+
 volumes:
   neo4j_data:
   neo4j_logs:
@@ -59,3 +87,5 @@ volumes:
   neo4j_plugins:
   minio_data:
   postgres_data:
+  prometheus_data:
+  grafana_data:

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: 'metatrack'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:8080' ]

--- a/k8s/nird/grafana/configmap-datasource.yaml
+++ b/k8s/nird/grafana/configmap-datasource.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: elixir-uit-ns11105k
+  labels:
+    app: grafana
+    component: monitoring
+    grafana_datasource: "1"
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus-service:9090
+        isDefault: true
+        jsonData:
+          timeInterval: 15s

--- a/k8s/nird/grafana/deployment.yaml
+++ b/k8s/nird/grafana/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: elixir-uit-ns11105k
+  labels:
+    app: grafana
+    component: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+        component: monitoring
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin
+                  key: username
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin
+                  key: password
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+            items:
+              - key: datasources.yaml
+                path: datasources.yaml

--- a/k8s/nird/grafana/ingress.yaml
+++ b/k8s/nird/grafana/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-ingress
+  namespace: elixir-uit-ns11105k
+  annotations:
+    appstore.uninett.no/contact_email: joshua.baskaran@uit.no
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - status.elixir-uit.sigma2.no
+      secretName: wildcard-tls
+  rules:
+    - host: status.elixir-uit.sigma2.no
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana-service
+                port:
+                  number: 3000

--- a/k8s/nird/grafana/service.yaml
+++ b/k8s/nird/grafana/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-service
+  namespace: elixir-uit-ns11105k
+spec:
+  selector:
+    app: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP

--- a/k8s/nird/ingress-netpol.yaml
+++ b/k8s/nird/ingress-netpol.yaml
@@ -77,3 +77,22 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-grafana-from-world
+  namespace: elixir-uit-ns11105k
+spec:
+  podSelector:
+    matchLabels:
+      app: grafana
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 3000

--- a/k8s/nird/prometheus/configmap.yaml
+++ b/k8s/nird/prometheus/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: elixir-uit-ns11105k
+  labels:
+    app: prometheus
+    component: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+    scrape_configs:
+      - job_name: 'prometheus'
+        static_configs:
+          - targets: ['localhost:9090']
+      - job_name: 'metatrack-api'
+        metrics_path: /actuator/prometheus
+        scrape_interval: 15s
+        static_configs:
+          - targets: ['metatrack-service:8090']

--- a/k8s/nird/prometheus/deployment.yaml
+++ b/k8s/nird/prometheus/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: elixir-uit-ns11105k
+  labels:
+    app: prometheus
+    component: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+        component: monitoring
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+            - name: data
+              mountPath: /prometheus
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+            items:
+              - key: prometheus.yml
+                path: prometheus.yml
+        - name: data
+          emptyDir: {}

--- a/k8s/nird/prometheus/service.yaml
+++ b/k8s/nird/prometheus/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-service
+  namespace: elixir-uit-ns11105k
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+  type: ClusterIP

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,14 @@
             <artifactId>keycloak-admin-client</artifactId>
             <version>26.0.6</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/no/metatrack/api/config/security/SecurityConfig.java
+++ b/src/main/java/no/metatrack/api/config/security/SecurityConfig.java
@@ -65,6 +65,8 @@ public class SecurityConfig {
 				.permitAll()
 				.requestMatchers("/actuator/health/**")
 				.permitAll()
+				.requestMatchers("/actuator/prometheus")
+				.permitAll()
 				.requestMatchers("/api/**")
 				.authenticated()
 				.anyRequest()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,3 +43,12 @@ logging:
 keycloak:
   realm: metatrack
   url: http://localhost:8090
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    prometheus:
+      access: unrestricted


### PR DESCRIPTION
Adds Prometheus and Grafana to Docker Compose setup for monitoring capabilities. Configures Prometheus to scrape metrics from the Metatrack API. Updates application configuration to expose Prometheus metrics and includes necessary dependencies in `pom.xml`.